### PR TITLE
Cache translate maps on the client and do not resend them every time

### DIFF
--- a/src/main/java/com/dzen/campfire/api/requests/accounts/RAccountsLogin.kt
+++ b/src/main/java/com/dzen/campfire/api/requests/accounts/RAccountsLogin.kt
@@ -8,7 +8,9 @@ import com.sup.dev.java.libs.json.Json
 
 open class RAccountsLogin(
         var tokenNotification: String,
-        var languageId: Long
+        var languageId: Long,
+        var translateMapHash: Int,
+        var translateMapHashEng: Int
 ) : Request<RAccountsLogin.Response>() {
 
     init {
@@ -19,6 +21,8 @@ open class RAccountsLogin(
     override fun jsonSub(inp: Boolean, json: Json) {
         tokenNotification = json.m(inp, "tokenNotification", tokenNotification)
         languageId = json.m(inp, "languageId", languageId)
+        translateMapHash = json.m(inp, "translateMapHash", translateMapHash)
+        translateMapHashEng = json.m(inp, "translateMapHashEng", translateMapHashEng)
     }
 
     override fun instanceResponse(json: Json): Response {
@@ -37,6 +41,8 @@ open class RAccountsLogin(
         var translate_language_id = 0L
         var translate_map: HashMap<String, Translate> = HashMap()
         var translate_map_eng: HashMap<String, Translate> = HashMap()
+        var translateMapHash: Int = 0
+        var translateMapHashEng: Int = 0
 
         var serverTime = 0L
         var settings = AccountSettings()
@@ -54,7 +60,9 @@ open class RAccountsLogin(
                     hasSubscribes: Boolean,
                     translate_language_id: Long,
                     translate_map: HashMap<String, Translate>,
-                    translate_map_eng: HashMap<String, Translate>) {
+                    translate_map_eng: HashMap<String, Translate>,
+                    translateMapHash: Int,
+                    translateMapHashEng: Int) {
             this.version = version
             this.supported = supported
             this.supportedVersion = supportedVersion
@@ -66,6 +74,8 @@ open class RAccountsLogin(
             this.translate_language_id = translate_language_id
             this.translate_map = translate_map
             this.translate_map_eng = translate_map_eng
+            this.translateMapHash = translateMapHash
+            this.translateMapHashEng = translateMapHashEng
         }
 
         override fun json(inp: Boolean, json: Json) {
@@ -78,6 +88,8 @@ open class RAccountsLogin(
             hasSubscribes = json.m(inp, "hasSubscribes", hasSubscribes)
             settings = json.m(inp, "settings", settings, AccountSettings::class)
             translate_language_id = json.m(inp, "translate_language_id", translate_language_id)
+            translateMapHash = json.m(inp, "translateMapHash", translateMapHash)
+            translateMapHashEng = json.m(inp, "translateMapHashEng", translateMapHashEng)
 
             if (inp) {
                 json.m(inp, "translate_map_k", translate_map.keys.toTypedArray())

--- a/src/main/java/com/dzen/campfire/api/requests/translates/RTranslateGetMap.kt
+++ b/src/main/java/com/dzen/campfire/api/requests/translates/RTranslateGetMap.kt
@@ -26,19 +26,23 @@ open class RTranslateGetMap(
 
         var translate_language_id = 0L
         var translate_map: HashMap<String, Translate> = HashMap()
+        var translateMapHash: Int = 0
 
         constructor(json: Json) {
             json(false, json)
         }
 
         constructor(translate_language_id: Long,
-                translate_map: HashMap<String, Translate>) {
+                translate_map: HashMap<String, Translate>,
+                translateMapHash: Int) {
             this.translate_language_id = translate_language_id
             this.translate_map = translate_map
+            this.translateMapHash = translateMapHash
         }
 
         override fun json(inp: Boolean, json: Json) {
             translate_language_id = json.m(inp, "translate_language_id", translate_language_id)
+            translateMapHash = json.m(inp, "translateMapHash", translateMapHash)
             if (inp) {
                 json.m(inp, "translate_map_k", translate_map.keys.toTypedArray())
                 json.m(inp, "translate_map_v", translate_map.values.toTypedArray())


### PR DESCRIPTION
See also:
* ZeonXX/CampfireSDK#6
* ZeonXX/CampfireServer#7
* ZeonXX/Campfire#4

The translate maps are hashed on the server and these hashes are sent to the client and saved there. When logging in again the server and the client compare these hashes. If they match, the translate maps are not sent.